### PR TITLE
Changing to take the handler provider via factory method.

### DIFF
--- a/Obvs.MessageDispatcher.Tests/Obvs.MessageDispatcher.Tests.csproj
+++ b/Obvs.MessageDispatcher.Tests/Obvs.MessageDispatcher.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
+  <Import Project="..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -39,20 +38,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=3.3.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.3.3.0\lib\net45\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.3.3.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions.Core, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Moq, Version=4.2.1502.911, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
+    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Obvs, Version=1.6.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Obvs.1.6.2\lib\net45\Obvs.dll</HintPath>
+    <Reference Include="Obvs, Version=2.2.0.42, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Obvs.2.2.0.42\lib\net45\Obvs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -78,12 +77,16 @@
       <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -136,8 +139,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
-    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Obvs.MessageDispatcher.Tests/packages.config
+++ b/Obvs.MessageDispatcher.Tests/packages.config
@@ -1,17 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="3.3.0" targetFramework="net452" userInstalled="true" />
-  <package id="Moq" version="4.2.1502.911" targetFramework="net452" userInstalled="true" />
-  <package id="Obvs" version="1.6.2" targetFramework="net452" userInstalled="true" />
+  <package id="FluentAssertions" version="4.2.1" targetFramework="net452" userInstalled="true" />
+  <package id="Moq" version="4.2.1510.2205" targetFramework="net452" userInstalled="true" />
+  <package id="Obvs" version="2.2.0.42" targetFramework="net452" userInstalled="true" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net452" userInstalled="true" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" userInstalled="true" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="net452" userInstalled="true" />
   <package id="Rx-Main" version="2.2.5" targetFramework="net452" userInstalled="true" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net452" userInstalled="true" />
-  <package id="xunit" version="2.0.0" targetFramework="net452" userInstalled="true" />
+  <package id="xunit" version="2.1.0" targetFramework="net452" userInstalled="true" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" userInstalled="true" />
-  <package id="xunit.assert" version="2.0.0" targetFramework="net452" userInstalled="true" />
-  <package id="xunit.core" version="2.0.0" targetFramework="net452" userInstalled="true" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net452" userInstalled="true" />
-  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net452" userInstalled="true" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net452" userInstalled="true" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net452" userInstalled="true" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net452" userInstalled="true" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net452" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net452" userInstalled="true" />
 </packages>

--- a/Obvs.MessageDispatcher/IMessageDispatcher.cs
+++ b/Obvs.MessageDispatcher/IMessageDispatcher.cs
@@ -1,23 +1,22 @@
-﻿using Obvs.Types;
-using System;
-using System.Threading;
+﻿using System;
+using Obvs.Types;
 
 namespace Obvs.MessageDispatcher
 {
-	public interface IMessageDispatcher
+    public interface IMessageDispatcher<TMessage>
 	{
-		IObservable<MessageDispatchResult> Run(IObservable<IMessage> messages, CancellationToken cancellationToken);
+		IObservable<MessageDispatchResult<TMessage>> Run(IObservable<TMessage> messages);
 	}
 
-	public class MessageDispatchResult
+	public class MessageDispatchResult<TMessage>
 	{
-		public MessageDispatchResult(IMessage message, bool handled)
+		public MessageDispatchResult(TMessage message, bool handled)
 		{
 			this.Message = message;
 			this.Handled = handled;
 		}
 
-		public IMessage Message
+		public TMessage Message
 		{
 			get;
 			private set;

--- a/Obvs.MessageDispatcher/IMessageHandler.cs
+++ b/Obvs.MessageDispatcher/IMessageHandler.cs
@@ -1,16 +1,14 @@
-﻿using Obvs.Types;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 
 namespace Obvs.MessageDispatcher
 {
-	public interface IMessageHandler
+    public interface IMessageHandler
 	{
 
 	}
 
 	public interface IMessageHandler<TMessage> : IMessageHandler
-		where TMessage : IMessage
 	{
 		Task HandleAsync(TMessage message, CancellationToken cancellationToken);
 	}

--- a/Obvs.MessageDispatcher/IMessageHandlerProvider.cs
+++ b/Obvs.MessageDispatcher/IMessageHandlerProvider.cs
@@ -1,9 +1,7 @@
-﻿using Obvs.Types;
-
-namespace Obvs.MessageDispatcher
+﻿namespace Obvs.MessageDispatcher
 {
-	public interface IMessageHandlerProvider
+    public interface IMessageHandlerProvider
 	{
-		IMessageHandler<TMessage> Provide<TMessage>() where TMessage : IMessage;
+        IMessageHandler<TMessage> GetMessageHandler<TMessage>();
 	}
 }

--- a/Obvs.MessageDispatcher/Obvs.MessageDispatcher.csproj
+++ b/Obvs.MessageDispatcher/Obvs.MessageDispatcher.csproj
@@ -30,8 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Obvs, Version=1.6.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Obvs.1.6.2\lib\net45\Obvs.dll</HintPath>
+    <Reference Include="Obvs, Version=2.2.0.42, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Obvs.2.2.0.42\lib\net45\Obvs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Obvs.MessageDispatcher/packages.config
+++ b/Obvs.MessageDispatcher/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Obvs" version="1.6.2" targetFramework="net452" userInstalled="true" />
+  <package id="Obvs" version="2.2.0.42" targetFramework="net452" userInstalled="true" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net452" userInstalled="true" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" userInstalled="true" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="net452" userInstalled="true" />


### PR DESCRIPTION
- Now requiring Func<IMessageHandlerProvider> as dependency. A new provider is created via the factory per message so that which will allow for per message lifetime scoping if the upstream consumer of the class so chooses.
- Upgrading to latest newer Obvs framework changes meant breaking dependency on IMessage since that is no longer required
- Updated all other dependent packages
