### PR TITLE
Renaming IMessageHandlerProvider -> IMessageHandlerSelector

### DIFF
--- a/Obvs.MessageDispatcher/IMessageHandlerProvider.cs
+++ b/Obvs.MessageDispatcher/IMessageHandlerProvider.cs
@@ -1,7 +1,0 @@
-﻿namespace Obvs.MessageDispatcher
-{
-    public interface IMessageHandlerProvider
-	{
-        IMessageHandler<TMessage> GetMessageHandler<TMessage>();
-	}
-}

--- a/Obvs.MessageDispatcher/IMessageHandlerSelector.cs
+++ b/Obvs.MessageDispatcher/IMessageHandlerSelector.cs
@@ -1,0 +1,7 @@
+﻿namespace Obvs.MessageDispatcher
+{
+    public interface IMessageHandlerSelector
+	{
+        IMessageHandler<TMessage> SelectMessageHandler<TMessage>(TMessage message);
+	}
+}

--- a/Obvs.MessageDispatcher/Obvs.MessageDispatcher.csproj
+++ b/Obvs.MessageDispatcher/Obvs.MessageDispatcher.csproj
@@ -62,7 +62,7 @@
   <ItemGroup>
     <Compile Include="IMessageDispatcher.cs" />
     <Compile Include="IMessageHandler.cs" />
-    <Compile Include="IMessageHandlerProvider.cs" />
+    <Compile Include="IMessageHandlerSelector.cs" />
     <Compile Include="MessageDispatcher.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
- Renaming the interface and the method to Selector/Select
- Noticed bug in MessageDispatcher where logic was not actually using the newly constructed IMessageHandlerSelector, it was always locked into the first instance. Also wrote test to verify this from now on.
